### PR TITLE
fix(scan): add SARIF 2.1.0 output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Dockerfile uses undeclared variables:
 - `--dir` (required): Directory to scan for source files
 - `--env-file` (required): Path to the .env file
 - `--ignore` (optional): Comma-separated list of directories to ignore
-- `--format` (optional): Output format - `text` (default) or `json`
+- `--format` (optional): Output format - `text` (default), `json`, or `sarif`
 
 ## Exit Codes
 
@@ -221,6 +221,20 @@ check-env:
   script:
     - ./capture scan --dir . --env-file .env
 ```
+
+**SARIF Format (GitHub Code Scanning):**
+```yaml
+# GitHub Actions with SARIF upload
+- name: Run capture scan
+  run: capture scan --dir . --env-file .env --format sarif > results.sarif
+
+- name: Upload SARIF results
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+See [docs/SARIF_OUTPUT.md](docs/SARIF_OUTPUT.md) for the full SARIF output format documentation.
 
 ## How It Works
 

--- a/cmd/capture/cmd/scan.go
+++ b/cmd/capture/cmd/scan.go
@@ -51,13 +51,13 @@ func init() {
 	scanCmd.Flags().StringVar(&scanConfig.Dir, "dir", ".", "Directory to scan (required)")
 	scanCmd.Flags().StringVar(&scanConfig.EnvFile, "env-file", ".env", "Path to .env file (required)")
 	scanCmd.Flags().StringSliceVar(&scanConfig.Ignore, "ignore", []string{}, "Comma-separated list of directories to ignore")
-	scanCmd.Flags().StringVar(&scanConfig.Format, "format", "text", "Output format: text or json")
+	scanCmd.Flags().StringVar(&scanConfig.Format, "format", "text", "Output format: text, json, or sarif")
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
 	// Validate format flag
-	if scanConfig.Format != "text" && scanConfig.Format != "json" {
-		fmt.Fprintf(os.Stderr, "Error: invalid format '%s'. Must be 'text' or 'json'\n", scanConfig.Format)
+	if scanConfig.Format != "text" && scanConfig.Format != "json" && scanConfig.Format != "sarif" {
+		fmt.Fprintf(os.Stderr, "Error: invalid format '%s'. Must be 'text', 'json', or 'sarif'\n", scanConfig.Format)
 		return NewExitError(fmt.Errorf("invalid format"), 2)
 	}
 
@@ -255,12 +255,18 @@ func executeScan(config *ScanConfig) int {
 	}
 
 	// Step 6: Generate report based on format
-	if config.Format == "json" {
+	switch config.Format {
+	case "json":
 		if err := rep.ReportJSON(reportData); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to generate JSON report: %v\n", err)
 			return 2
 		}
-	} else {
+	case "sarif":
+		if err := rep.ReportSARIF(reportData); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to generate SARIF report: %v\n", err)
+			return 2
+		}
+	default:
 		// Text format (default)
 		rep.Report(reportData)
 

--- a/cmd/capture/sarif_integration_test.go
+++ b/cmd/capture/sarif_integration_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yhaliwaizman/capture/internal/types"
+)
+
+// TestCLI_SARIFFormatAccepted tests that --format sarif is accepted without error
+// Requirements: 1.1
+func TestCLI_SARIFFormatAccepted(t *testing.T) {
+	// Build the binary
+	buildCmd := exec.Command("go", "build", "-o", "capture-test", ".")
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer os.Remove("capture-test")
+
+	// Create temp directory for test
+	tmpDir := t.TempDir()
+
+	// Create test .env file
+	envPath := filepath.Join(tmpDir, ".env")
+	if err := os.WriteFile(envPath, []byte("API_KEY=secret\n"), 0644); err != nil {
+		t.Fatalf("Failed to create .env file: %v", err)
+	}
+
+	// Create test source file that uses the variable (no mismatches)
+	jsPath := filepath.Join(tmpDir, "app.js")
+	if err := os.WriteFile(jsPath, []byte("const key = process.env.API_KEY;\n"), 0644); err != nil {
+		t.Fatalf("Failed to create app.js file: %v", err)
+	}
+
+	// Run scan with SARIF format
+	cmd := exec.Command("./capture-test", "scan",
+		"--dir", tmpDir,
+		"--env-file", envPath,
+		"--format", "sarif")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("Expected zero exit code for --format sarif with no mismatches, got error: %v\nStderr: %s", err, stderr.String())
+	}
+
+	// Verify output is valid SARIF JSON
+	var doc types.SARIFDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("Failed to parse SARIF output: %v\nOutput: %s", err, stdout.String())
+	}
+
+	if doc.Version != "2.1.0" {
+		t.Errorf("SARIF version = %q, want %q", doc.Version, "2.1.0")
+	}
+}
+
+// TestCLI_InvalidFormatListsSARIF tests that invalid format error message includes sarif
+// Requirements: 1.4
+func TestCLI_InvalidFormatListsSARIF(t *testing.T) {
+	// Build the binary
+	buildCmd := exec.Command("go", "build", "-o", "capture-test", ".")
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer os.Remove("capture-test")
+
+	// Create temp directory for test
+	tmpDir := t.TempDir()
+
+	// Create test .env file
+	envPath := filepath.Join(tmpDir, ".env")
+	if err := os.WriteFile(envPath, []byte("API_KEY=secret\n"), 0644); err != nil {
+		t.Fatalf("Failed to create .env file: %v", err)
+	}
+
+	// Run scan with invalid format
+	cmd := exec.Command("./capture-test", "scan",
+		"--dir", tmpDir,
+		"--env-file", envPath,
+		"--format", "xml")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Error("Expected non-zero exit code for invalid format")
+	}
+
+	stderrOutput := stderr.String()
+
+	// Check that error message mentions sarif as a valid format
+	if !strings.Contains(stderrOutput, "sarif") {
+		t.Errorf("Expected 'sarif' in error message, got: %s", stderrOutput)
+	}
+
+	// Check that error message also mentions text and json
+	if !strings.Contains(stderrOutput, "text") {
+		t.Errorf("Expected 'text' in error message, got: %s", stderrOutput)
+	}
+	if !strings.Contains(stderrOutput, "json") {
+		t.Errorf("Expected 'json' in error message, got: %s", stderrOutput)
+	}
+
+	// Verify exit code is 2
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 2 {
+			t.Errorf("Expected exit code 2, got %d", exitErr.ExitCode())
+		}
+	}
+}

--- a/docs/SARIF_OUTPUT.md
+++ b/docs/SARIF_OUTPUT.md
@@ -1,0 +1,292 @@
+# SARIF Output Format
+
+The `--format sarif` flag produces output in [SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format) 2.1.0, an OASIS standard for static analysis tool output. SARIF enables integration with GitHub Code Scanning, Azure DevOps, and other security platforms that consume standardized findings.
+
+## Usage
+
+```bash
+capture scan --dir . --env-file .env --format sarif
+```
+
+To save results to a file:
+
+```bash
+capture scan --dir . --env-file .env --format sarif > results.sarif
+```
+
+## Rule Definitions
+
+Each category of environment variable mismatch maps to a distinct SARIF rule. Rules are only included in the output when at least one finding exists for that category.
+
+| Rule ID | Name | Description | Level |
+|---------|------|-------------|-------|
+| ENV001 | `unused-variable` | Variable is declared in .env but not used in code | `warning` |
+| ENV002 | `missing-variable` | Variable is used in code but not declared in .env | `error` |
+| ENV003 | `code-uses-not-in-docker` | Variable is used in code but not declared in Dockerfile or .env | `warning` |
+| ENV004 | `docker-declares-unused` | Variable is declared in Dockerfile but not used in code | `warning` |
+| ENV005 | `docker-uses-undeclared` | Variable is used in Dockerfile but not declared | `error` |
+
+### Severity Levels
+
+- **error**: The variable mismatch is likely to cause runtime failures (missing declarations)
+- **warning**: The variable mismatch indicates unused or orphaned configuration
+
+## Output Structure
+
+The SARIF output conforms to the [SARIF 2.1.0 schema](https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json). It contains a single run with tool metadata, rule definitions, and results.
+
+### Complete Example
+
+The following example shows SARIF output from a scan that found all five categories of mismatches:
+
+```json
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "capture",
+          "informationUri": "https://github.com/syncd-one/syncd",
+          "rules": [
+            {
+              "id": "ENV001",
+              "name": "unused-variable",
+              "shortDescription": {
+                "text": "Variable is declared in .env but not used in code"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#unused-variable"
+            },
+            {
+              "id": "ENV002",
+              "name": "missing-variable",
+              "shortDescription": {
+                "text": "Variable is used in code but not declared in .env"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#missing-variable"
+            },
+            {
+              "id": "ENV003",
+              "name": "code-uses-not-in-docker",
+              "shortDescription": {
+                "text": "Variable is used in code but not declared in Dockerfile or .env"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#code-uses-not-in-docker"
+            },
+            {
+              "id": "ENV004",
+              "name": "docker-declares-unused",
+              "shortDescription": {
+                "text": "Variable is declared in Dockerfile but not used in code"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#docker-declares-unused"
+            },
+            {
+              "id": "ENV005",
+              "name": "docker-uses-undeclared",
+              "shortDescription": {
+                "text": "Variable is used in Dockerfile but not declared"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#docker-uses-undeclared"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "ENV001",
+          "ruleIndex": 0,
+          "level": "warning",
+          "message": {
+            "text": "UNUSED_VAR: Variable is declared in .env but not used in code"
+          }
+        },
+        {
+          "ruleId": "ENV002",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "MISSING_VAR: Variable is used in code but not declared in .env"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.go"
+                },
+                "region": {
+                  "startLine": 10
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ENV003",
+          "ruleIndex": 2,
+          "level": "warning",
+          "message": {
+            "text": "CODE_VAR: Variable is used in code but not declared in Dockerfile or .env"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/config.go"
+                },
+                "region": {
+                  "startLine": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ENV004",
+          "ruleIndex": 3,
+          "level": "warning",
+          "message": {
+            "text": "DOCKER_UNUSED: Variable is declared in Dockerfile but not used in code"
+          }
+        },
+        {
+          "ruleId": "ENV005",
+          "ruleIndex": 4,
+          "level": "error",
+          "message": {
+            "text": "DOCKER_UNDECL: Variable is used in Dockerfile but not declared"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
+                "region": {
+                  "startLine": 5
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+### Empty Results
+
+When no mismatches are found, the output is a valid SARIF document with empty `results` and `rules` arrays:
+
+```json
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "capture",
+          "informationUri": "https://github.com/syncd-one/syncd",
+          "rules": []
+        }
+      },
+      "results": []
+    }
+  ]
+}
+```
+
+### Key Fields
+
+- **version**: Always `"2.1.0"`
+- **$schema**: Points to the official SARIF 2.1.0 JSON schema
+- **runs**: Contains exactly one run object
+- **tool.driver.name**: Always `"capture"`
+- **tool.driver.rules**: Only rules with at least one result are included
+- **results**: Sorted by `ruleId`, then alphabetically by variable name
+- **locations**: Included for ENV002, ENV003, and ENV005 results when location data is available; omitted for ENV001 and ENV004
+
+## Location Data
+
+Results for rules that have source location information include a `locations` array with physical location details:
+
+- **ENV002** (missing-variable): File path and line number where the variable is used in code
+- **ENV003** (code-uses-not-in-docker): File path and line number of the first usage in code
+- **ENV005** (docker-uses-undeclared): Dockerfile path and line number
+
+Results for **ENV001** (unused-variable) and **ENV004** (docker-declares-unused) omit the `locations` array since these findings relate to declarations without specific source code references.
+
+All file paths use forward-slash separators for cross-platform compatibility.
+
+## Deterministic Output
+
+SARIF output is fully deterministic — identical scan inputs always produce byte-identical output. This makes it safe to use in CI/CD pipelines for diffing and caching.
+
+## Exit Codes
+
+Exit codes are the same regardless of output format:
+
+- **0**: No mismatches detected
+- **1**: Mismatches found
+- **2**: Configuration error
+
+## GitHub Actions Integration
+
+Upload SARIF results to GitHub Code Scanning to see findings directly in pull requests and the Security tab:
+
+```yaml
+name: Environment Variable Scan
+
+on: [push, pull_request]
+
+jobs:
+  capture-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download capture
+        run: |
+          curl -L https://github.com/yhaliwaizman/capture/releases/latest/download/capture_Linux_x86_64.tar.gz | tar xz
+          chmod +x capture
+
+      - name: Run capture scan
+        run: ./capture scan --dir . --env-file .env --format sarif > results.sarif
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+This workflow:
+1. Checks out the repository
+2. Downloads the `capture` binary
+3. Runs a scan with `--format sarif` and writes output to `results.sarif`
+4. Uploads the SARIF file to GitHub Code Scanning using `github/codeql-action/upload-sarif`
+
+The `security-events: write` permission is required for the SARIF upload step.
+
+## Comparison with Other Formats
+
+| Feature | Text | JSON | SARIF |
+|---------|------|------|-------|
+| Human-readable | ✅ Yes | ❌ No | ❌ No |
+| Machine-parseable | ❌ Difficult | ✅ Easy | ✅ Easy |
+| GitHub Code Scanning | ❌ No | ❌ No | ✅ Yes |
+| Summary statistics | ❌ No | ✅ Yes | ❌ No |
+| Location data | ⚠️ First only | ✅ All | ✅ First |
+| Deterministic | ✅ Yes | ✅ Yes | ✅ Yes |
+| Default | ✅ Yes | ❌ No | ❌ No |
+
+## Notes
+
+- SARIF output goes to stdout; errors go to stderr
+- The output conforms to SARIF 2.1.0 and is accepted by GitHub Code Scanning, Azure DevOps, and other SARIF-compatible tools
+- No external dependencies are required — the output is generated using Go's standard `encoding/json` package

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -13,6 +13,7 @@ import (
 type Reporter interface {
 	Report(data types.ReportData)
 	ReportJSON(data types.ReportData) error
+	ReportSARIF(data types.ReportData) error
 }
 
 // ReporterImpl implements the Reporter interface

--- a/internal/reporter/reporter_sarif.go
+++ b/internal/reporter/reporter_sarif.go
@@ -1,0 +1,245 @@
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/yhaliwaizman/capture/internal/types"
+)
+
+const (
+	sarifVersion = "2.1.0"
+	sarifSchema  = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json"
+	toolName     = "capture"
+	toolInfoURI  = "https://github.com/syncd-one/syncd"
+)
+
+// sarifRuleDef holds the static definition for each rule.
+type sarifRuleDef struct {
+	id          string
+	name        string
+	description string
+	level       string
+}
+
+var sarifRules = []sarifRuleDef{
+	{id: "ENV001", name: "unused-variable", description: "Variable is declared in .env but not used in code", level: "warning"},
+	{id: "ENV002", name: "missing-variable", description: "Variable is used in code but not declared in .env", level: "error"},
+	{id: "ENV003", name: "code-uses-not-in-docker", description: "Variable is used in code but not declared in Dockerfile or .env", level: "warning"},
+	{id: "ENV004", name: "docker-declares-unused", description: "Variable is declared in Dockerfile but not used in code", level: "warning"},
+	{id: "ENV005", name: "docker-uses-undeclared", description: "Variable is used in Dockerfile but not declared", level: "error"},
+}
+
+// ReportSARIF formats and outputs the analysis results as SARIF 2.1.0 JSON.
+func (r *ReporterImpl) ReportSARIF(data types.ReportData) error {
+	results, activeRuleIDs := buildSARIFResults(data)
+	rules := buildSARIFRules(activeRuleIDs)
+
+	// Assign ruleIndex based on the filtered, sorted rules array
+	ruleIndexMap := make(map[string]int, len(rules))
+	for i, rule := range rules {
+		ruleIndexMap[rule.ID] = i
+	}
+	for i := range results {
+		results[i].RuleIndex = ruleIndexMap[results[i].RuleID]
+	}
+
+	doc := types.SARIFDocument{
+		Version: sarifVersion,
+		Schema:  sarifSchema,
+		Runs: []types.SARIFRun{
+			{
+				Tool: types.SARIFTool{
+					Driver: types.SARIFDriver{
+						Name:           toolName,
+						InformationURI: toolInfoURI,
+						Rules:          rules,
+					},
+				},
+				Results: results,
+			},
+		},
+	}
+
+	jsonBytes, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal SARIF: %w", err)
+	}
+
+	fmt.Fprintln(r.out, string(jsonBytes))
+	return nil
+}
+
+// buildSARIFRules returns the filtered, sorted rules array for the given active rule IDs.
+func buildSARIFRules(activeRuleIDs map[string]bool) []types.SARIFReportingDescriptor {
+	var rules []types.SARIFReportingDescriptor
+	for _, def := range sarifRules {
+		if !activeRuleIDs[def.id] {
+			continue
+		}
+		rules = append(rules, types.SARIFReportingDescriptor{
+			ID:   def.id,
+			Name: def.name,
+			ShortDescription: types.SARIFMessage{
+				Text: def.description,
+			},
+			HelpURI: toolInfoURI + "#" + def.name,
+		})
+	}
+	// sarifRules is already ordered by id, so rules inherits that order.
+	// Explicit sort for safety.
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].ID < rules[j].ID
+	})
+	return rules
+}
+
+// buildSARIFResults builds the sorted results slice and returns the set of active rule IDs.
+func buildSARIFResults(data types.ReportData) ([]types.SARIFResult, map[string]bool) {
+	activeRuleIDs := make(map[string]bool)
+	var results []types.SARIFResult
+
+	// ENV001 - unused variables (no locations)
+	unused := data.Unused
+	if unused == nil {
+		unused = []string{}
+	}
+	sortedUnused := make([]string, len(unused))
+	copy(sortedUnused, unused)
+	sort.Strings(sortedUnused)
+	for _, varName := range sortedUnused {
+		activeRuleIDs["ENV001"] = true
+		results = append(results, types.SARIFResult{
+			RuleID:  "ENV001",
+			Level:   "warning",
+			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is declared in .env but not used in code", varName)},
+		})
+	}
+
+	// ENV002 - missing variables (with locations from data.Missing)
+	missingVars := sortedKeys(data.Missing)
+	for _, varName := range missingVars {
+		activeRuleIDs["ENV002"] = true
+		loc := data.Missing[varName]
+		result := types.SARIFResult{
+			RuleID:  "ENV002",
+			Level:   "error",
+			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is used in code but not declared in .env", varName)},
+		}
+		if loc.FilePath != "" {
+			result.Locations = []types.SARIFLocation{
+				makeLocation(loc.FilePath, loc.LineNumber),
+			}
+		}
+		results = append(results, result)
+	}
+
+	// ENV003 - code uses not in docker (with first location)
+	codeVars := sortedKeysLocSlice(data.CodeUsesNotInDocker)
+	for _, varName := range codeVars {
+		activeRuleIDs["ENV003"] = true
+		locs := data.CodeUsesNotInDocker[varName]
+		result := types.SARIFResult{
+			RuleID:  "ENV003",
+			Level:   "warning",
+			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is used in code but not declared in Dockerfile or .env", varName)},
+		}
+		if len(locs) > 0 && locs[0].FilePath != "" {
+			result.Locations = []types.SARIFLocation{
+				makeLocation(locs[0].FilePath, locs[0].LineNumber),
+			}
+		}
+		results = append(results, result)
+	}
+
+	// ENV004 - docker declares unused (no locations)
+	dockerDeclaresUnused := data.DockerDeclaresUnused
+	if dockerDeclaresUnused == nil {
+		dockerDeclaresUnused = []string{}
+	}
+	sortedDockerDeclares := make([]string, len(dockerDeclaresUnused))
+	copy(sortedDockerDeclares, dockerDeclaresUnused)
+	sort.Strings(sortedDockerDeclares)
+	for _, varName := range sortedDockerDeclares {
+		activeRuleIDs["ENV004"] = true
+		results = append(results, types.SARIFResult{
+			RuleID:  "ENV004",
+			Level:   "warning",
+			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is declared in Dockerfile but not used in code", varName)},
+		})
+	}
+
+	// ENV005 - docker uses undeclared (with location)
+	dockerVars := sortedKeysLoc(data.DockerUsesUndeclared)
+	for _, varName := range dockerVars {
+		activeRuleIDs["ENV005"] = true
+		loc := data.DockerUsesUndeclared[varName]
+		result := types.SARIFResult{
+			RuleID:  "ENV005",
+			Level:   "error",
+			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is used in Dockerfile but not declared", varName)},
+		}
+		if loc.FilePath != "" {
+			result.Locations = []types.SARIFLocation{
+				makeLocation(loc.FilePath, loc.LineNumber),
+			}
+		}
+		results = append(results, result)
+	}
+
+	// Sort results by ruleId, then by variable name (extracted from message prefix)
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].RuleID != results[j].RuleID {
+			return results[i].RuleID < results[j].RuleID
+		}
+		return results[i].Message.Text < results[j].Message.Text
+	})
+
+	// Ensure non-nil slices for valid JSON
+	if results == nil {
+		results = []types.SARIFResult{}
+	}
+
+	return results, activeRuleIDs
+}
+
+// makeLocation creates a SARIFLocation with forward-slash path separators.
+func makeLocation(filePath string, lineNumber int) types.SARIFLocation {
+	return types.SARIFLocation{
+		PhysicalLocation: types.SARIFPhysicalLocation{
+			ArtifactLocation: types.SARIFArtifactLocation{
+				URI: filepath.ToSlash(filePath),
+			},
+			Region: types.SARIFRegion{
+				StartLine: lineNumber,
+			},
+		},
+	}
+}
+
+// sortedKeys returns sorted keys from a map[string]Location.
+func sortedKeys(m map[string]types.Location) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedKeysLocSlice returns sorted keys from a map[string][]Location.
+func sortedKeysLocSlice(m map[string][]types.Location) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedKeysLoc returns sorted keys from a map[string]Location (same as sortedKeys, aliased for clarity).
+func sortedKeysLoc(m map[string]types.Location) []string {
+	return sortedKeys(m)
+}

--- a/internal/reporter/reporter_sarif.go
+++ b/internal/reporter/reporter_sarif.go
@@ -74,7 +74,7 @@ func (r *ReporterImpl) ReportSARIF(data types.ReportData) error {
 
 // buildSARIFRules returns the filtered, sorted rules array for the given active rule IDs.
 func buildSARIFRules(activeRuleIDs map[string]bool) []types.SARIFReportingDescriptor {
-	var rules []types.SARIFReportingDescriptor
+	rules := []types.SARIFReportingDescriptor{}
 	for _, def := range sarifRules {
 		if !activeRuleIDs[def.id] {
 			continue

--- a/internal/reporter/reporter_sarif_golden_test.go
+++ b/internal/reporter/reporter_sarif_golden_test.go
@@ -1,0 +1,64 @@
+package reporter
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yhaliwaizman/capture/internal/types"
+)
+
+// TestReportSARIF_GoldenFull compares ReportSARIF output for a full scan
+// (all 5 mismatch categories) against the golden file for regression detection.
+func TestReportSARIF_GoldenFull(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"UNUSED_VAR"},
+		Missing: map[string]types.Location{
+			"MISSING_VAR": {FilePath: "src/app.go", LineNumber: 10},
+		},
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"CODE_VAR": {{FilePath: "src/config.go", LineNumber: 20}},
+		},
+		DockerDeclaresUnused: []string{"DOCKER_UNUSED"},
+		DockerUsesUndeclared: map[string]types.Location{
+			"DOCKER_UNDECL": {FilePath: "Dockerfile", LineNumber: 5},
+		},
+	}
+
+	var buf bytes.Buffer
+	r := &ReporterImpl{out: &buf}
+	if err := r.ReportSARIF(data); err != nil {
+		t.Fatalf("ReportSARIF: %v", err)
+	}
+
+	golden, err := os.ReadFile(filepath.Join("testdata", "sarif_expected_full.json"))
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), golden) {
+		t.Errorf("output does not match golden file testdata/sarif_expected_full.json\n--- got ---\n%s\n--- want ---\n%s", buf.String(), string(golden))
+	}
+}
+
+// TestReportSARIF_GoldenEmpty compares ReportSARIF output for an empty scan
+// (no mismatches) against the golden file for regression detection.
+func TestReportSARIF_GoldenEmpty(t *testing.T) {
+	data := types.ReportData{}
+
+	var buf bytes.Buffer
+	r := &ReporterImpl{out: &buf}
+	if err := r.ReportSARIF(data); err != nil {
+		t.Fatalf("ReportSARIF: %v", err)
+	}
+
+	golden, err := os.ReadFile(filepath.Join("testdata", "sarif_expected_empty.json"))
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), golden) {
+		t.Errorf("output does not match golden file testdata/sarif_expected_empty.json\n--- got ---\n%s\n--- want ---\n%s", buf.String(), string(golden))
+	}
+}

--- a/internal/reporter/reporter_sarif_property_test.go
+++ b/internal/reporter/reporter_sarif_property_test.go
@@ -1,0 +1,269 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/yhaliwaizman/capture/internal/types"
+)
+
+// randomVarName generates a random environment variable name.
+func randomVarName(r *rand.Rand) string {
+	length := r.Intn(8) + 1
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('A' + r.Intn(26))
+	}
+	return string(b)
+}
+
+// randomLocation generates a random Location.
+func randomLocation(r *rand.Rand) types.Location {
+	pathLen := r.Intn(5) + 1
+	pathBytes := make([]byte, pathLen)
+	for i := range pathBytes {
+		pathBytes[i] = byte('a' + r.Intn(26))
+	}
+	return types.Location{
+		FilePath:   string(pathBytes) + ".go",
+		LineNumber: r.Intn(500) + 1,
+	}
+}
+
+// generateReportData creates a random ReportData for property testing.
+func generateReportData(r *rand.Rand) types.ReportData {
+	data := types.ReportData{}
+
+	// Unused (0-3 entries)
+	n := r.Intn(4)
+	if n > 0 {
+		data.Unused = make([]string, n)
+		for i := range data.Unused {
+			data.Unused[i] = randomVarName(r)
+		}
+	}
+
+	// Missing (0-3 entries)
+	n = r.Intn(4)
+	if n > 0 {
+		data.Missing = make(map[string]types.Location, n)
+		for i := 0; i < n; i++ {
+			data.Missing[randomVarName(r)] = randomLocation(r)
+		}
+	}
+
+	// CodeUsesNotInDocker (0-3 entries)
+	n = r.Intn(4)
+	if n > 0 {
+		data.CodeUsesNotInDocker = make(map[string][]types.Location, n)
+		for i := 0; i < n; i++ {
+			locCount := r.Intn(3) + 1
+			locs := make([]types.Location, locCount)
+			for j := range locs {
+				locs[j] = randomLocation(r)
+			}
+			data.CodeUsesNotInDocker[randomVarName(r)] = locs
+		}
+	}
+
+	// DockerDeclaresUnused (0-3 entries)
+	n = r.Intn(4)
+	if n > 0 {
+		data.DockerDeclaresUnused = make([]string, n)
+		for i := range data.DockerDeclaresUnused {
+			data.DockerDeclaresUnused[i] = randomVarName(r)
+		}
+	}
+
+	// DockerUsesUndeclared (0-3 entries)
+	n = r.Intn(4)
+	if n > 0 {
+		data.DockerUsesUndeclared = make(map[string]types.Location, n)
+		for i := 0; i < n; i++ {
+			data.DockerUsesUndeclared[randomVarName(r)] = randomLocation(r)
+		}
+	}
+
+	return data
+}
+
+// reportDataGenValue wraps ReportData for testing/quick.
+type reportDataGenValue struct {
+	Data types.ReportData
+}
+
+// Generate implements quick.Generator for reportDataGenValue.
+func (reportDataGenValue) Generate(r *rand.Rand, size int) reflect.Value {
+	return reflect.ValueOf(reportDataGenValue{Data: generateReportData(r)})
+}
+
+// sarifFromData is a helper that runs ReportSARIF and returns the raw output.
+func sarifFromData(data types.ReportData) ([]byte, error) {
+	var out, errBuf bytes.Buffer
+	r := NewReporter(&out, &errBuf)
+	if err := r.ReportSARIF(data); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// Feature: sarif-output-format, Property 7: SARIF Serialization Round-Trip
+// Validates: Requirements 10.7, 6.3
+func TestProperty_SARIFRoundTripValidity(t *testing.T) {
+	f := func(input reportDataGenValue) bool {
+		raw, err := sarifFromData(input.Data)
+		if err != nil {
+			t.Logf("ReportSARIF error: %v", err)
+			return false
+		}
+
+		// Deserialize back into SARIFDocument
+		var doc types.SARIFDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Logf("Unmarshal error: %v", err)
+			return false
+		}
+
+		// Verify structural validity
+		if doc.Version != "2.1.0" {
+			t.Logf("version = %q, want 2.1.0", doc.Version)
+			return false
+		}
+		if doc.Schema == "" {
+			t.Log("schema is empty")
+			return false
+		}
+		if len(doc.Runs) != 1 {
+			t.Logf("runs count = %d, want 1", len(doc.Runs))
+			return false
+		}
+		run := doc.Runs[0]
+		if run.Tool.Driver.Name != "capture" {
+			t.Logf("driver name = %q, want capture", run.Tool.Driver.Name)
+			return false
+		}
+		if run.Tool.Driver.InformationURI == "" {
+			t.Log("informationUri is empty")
+			return false
+		}
+		if run.Results == nil {
+			t.Log("results is nil")
+			return false
+		}
+		if run.Tool.Driver.Rules == nil && len(run.Results) > 0 {
+			t.Log("rules is nil but results exist")
+			return false
+		}
+		return true
+	}
+
+	cfg := &quick.Config{MaxCount: 100}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Errorf("Property failed: %v", err)
+	}
+}
+
+// Feature: sarif-output-format, Property 6: Output Idempotence
+// Validates: Requirements 7.3, 10.6
+func TestProperty_SARIFDeterministicOutput(t *testing.T) {
+	f := func(input reportDataGenValue) bool {
+		out1, err1 := sarifFromData(input.Data)
+		if err1 != nil {
+			t.Logf("First call error: %v", err1)
+			return false
+		}
+
+		out2, err2 := sarifFromData(input.Data)
+		if err2 != nil {
+			t.Logf("Second call error: %v", err2)
+			return false
+		}
+
+		if !bytes.Equal(out1, out2) {
+			t.Log("Outputs differ between two calls with identical input")
+			return false
+		}
+		return true
+	}
+
+	cfg := &quick.Config{MaxCount: 100}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Errorf("Property failed: %v", err)
+	}
+}
+
+// Feature: sarif-output-format, Property 2: Rule-Result Correspondence
+// Validates: Requirements 3.7
+func TestProperty_SARIFRuleResultCorrespondence(t *testing.T) {
+	f := func(input reportDataGenValue) bool {
+		raw, err := sarifFromData(input.Data)
+		if err != nil {
+			t.Logf("ReportSARIF error: %v", err)
+			return false
+		}
+
+		var doc types.SARIFDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Logf("Unmarshal error: %v", err)
+			return false
+		}
+
+		run := doc.Runs[0]
+		rules := run.Tool.Driver.Rules
+		results := run.Results
+
+		// Build set of ruleIds that appear in results
+		resultRuleIDs := make(map[string]bool)
+		for _, r := range results {
+			resultRuleIDs[r.RuleID] = true
+		}
+
+		// Every rule in rules array must have at least one result referencing it
+		for _, rule := range rules {
+			if !resultRuleIDs[rule.ID] {
+				t.Logf("Rule %q in rules array but no result references it", rule.ID)
+				return false
+			}
+		}
+
+		// Every ruleId in results must have a corresponding rule in the rules array
+		ruleIDs := make(map[string]bool)
+		for _, rule := range rules {
+			ruleIDs[rule.ID] = true
+		}
+		for _, r := range results {
+			if !ruleIDs[r.RuleID] {
+				t.Logf("Result references ruleId %q but no rule exists for it", r.RuleID)
+				return false
+			}
+		}
+
+		// Verify ruleIndex is valid for each result
+		for i, r := range results {
+			if r.RuleIndex < 0 || r.RuleIndex >= len(rules) {
+				t.Logf("Result[%d] ruleIndex %d out of range [0, %d)", i, r.RuleIndex, len(rules))
+				return false
+			}
+			if rules[r.RuleIndex].ID != r.RuleID {
+				t.Logf("Result[%d] ruleIndex %d points to %q, expected %q",
+					i, r.RuleIndex, rules[r.RuleIndex].ID, r.RuleID)
+				return false
+			}
+		}
+
+		return true
+	}
+
+	cfg := &quick.Config{MaxCount: 100}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Errorf("Property failed: %v", err)
+	}
+}
+
+// Ensure reportDataGenValue is used (avoid unused import for fmt if needed)
+var _ = fmt.Sprintf

--- a/internal/reporter/reporter_sarif_test.go
+++ b/internal/reporter/reporter_sarif_test.go
@@ -1,0 +1,404 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/yhaliwaizman/capture/internal/types"
+)
+
+// helper to run ReportSARIF and return parsed document
+func runSARIF(t *testing.T, data types.ReportData) (types.SARIFDocument, string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	r := NewReporter(&out, &errBuf)
+	if err := r.ReportSARIF(data); err != nil {
+		t.Fatalf("ReportSARIF returned error: %v", err)
+	}
+	raw := out.String()
+	var doc types.SARIFDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("Failed to unmarshal SARIF output: %v\nOutput:\n%s", err, raw)
+	}
+	return doc, raw
+}
+
+// Task 2.1: ReportSARIF writes to r.out and returns error on marshal failure
+func TestReportSARIF_WritesToOut(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	r := NewReporter(&out, &errBuf)
+	err := r.ReportSARIF(types.ReportData{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected output, got empty")
+	}
+}
+
+// Task 2.1: Verify SARIF envelope structure
+func TestReportSARIF_EnvelopeStructure(t *testing.T) {
+	doc, _ := runSARIF(t, types.ReportData{})
+
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want %q", doc.Version, "2.1.0")
+	}
+	if doc.Schema != "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json" {
+		t.Errorf("schema = %q, want SARIF 2.1.0 schema URL", doc.Schema)
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("runs count = %d, want 1", len(doc.Runs))
+	}
+	if doc.Runs[0].Tool.Driver.Name != "capture" {
+		t.Errorf("driver name = %q, want %q", doc.Runs[0].Tool.Driver.Name, "capture")
+	}
+	if doc.Runs[0].Tool.Driver.InformationURI == "" {
+		t.Error("informationUri is empty")
+	}
+}
+
+// Task 2.2: Rule generation - only rules with results are included
+func TestReportSARIF_RuleFiltering(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"FOO"},
+		Missing: map[string]types.Location{
+			"BAR": {FilePath: "app.go", LineNumber: 5},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	rules := doc.Runs[0].Tool.Driver.Rules
+
+	if len(rules) != 2 {
+		t.Fatalf("rules count = %d, want 2", len(rules))
+	}
+	if rules[0].ID != "ENV001" {
+		t.Errorf("rules[0].ID = %q, want ENV001", rules[0].ID)
+	}
+	if rules[1].ID != "ENV002" {
+		t.Errorf("rules[1].ID = %q, want ENV002", rules[1].ID)
+	}
+}
+
+// Task 2.2: All 5 rules present when all categories populated
+func TestReportSARIF_AllFiveRules(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"A"},
+		Missing: map[string]types.Location{
+			"B": {FilePath: "f.go", LineNumber: 1},
+		},
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"C": {{FilePath: "g.go", LineNumber: 2}},
+		},
+		DockerDeclaresUnused: []string{"D"},
+		DockerUsesUndeclared: map[string]types.Location{
+			"E": {FilePath: "Dockerfile", LineNumber: 3},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	rules := doc.Runs[0].Tool.Driver.Rules
+
+	if len(rules) != 5 {
+		t.Fatalf("rules count = %d, want 5", len(rules))
+	}
+	expectedIDs := []string{"ENV001", "ENV002", "ENV003", "ENV004", "ENV005"}
+	for i, id := range expectedIDs {
+		if rules[i].ID != id {
+			t.Errorf("rules[%d].ID = %q, want %q", i, rules[i].ID, id)
+		}
+		if rules[i].Name == "" {
+			t.Errorf("rules[%d].Name is empty", i)
+		}
+		if rules[i].ShortDescription.Text == "" {
+			t.Errorf("rules[%d].ShortDescription.Text is empty", i)
+		}
+		if rules[i].HelpURI == "" {
+			t.Errorf("rules[%d].HelpURI is empty", i)
+		}
+	}
+}
+
+// Task 2.2: Rules sorted by id
+func TestReportSARIF_RulesSortedByID(t *testing.T) {
+	data := types.ReportData{
+		DockerUsesUndeclared: map[string]types.Location{
+			"Z": {FilePath: "Dockerfile", LineNumber: 1},
+		},
+		Unused: []string{"A"},
+	}
+	doc, _ := runSARIF(t, data)
+	rules := doc.Runs[0].Tool.Driver.Rules
+
+	if len(rules) != 2 {
+		t.Fatalf("rules count = %d, want 2", len(rules))
+	}
+	if rules[0].ID != "ENV001" || rules[1].ID != "ENV005" {
+		t.Errorf("rules not sorted: got %s, %s", rules[0].ID, rules[1].ID)
+	}
+}
+
+// Task 2.3: Result mapping - correct ruleId and level
+func TestReportSARIF_ResultMapping(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"UNUSED_VAR"},
+		Missing: map[string]types.Location{
+			"MISSING_VAR": {FilePath: "app.go", LineNumber: 10},
+		},
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"CODE_VAR": {{FilePath: "src.go", LineNumber: 20}},
+		},
+		DockerDeclaresUnused: []string{"DOCKER_UNUSED"},
+		DockerUsesUndeclared: map[string]types.Location{
+			"DOCKER_UNDECL": {FilePath: "Dockerfile", LineNumber: 30},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	results := doc.Runs[0].Results
+
+	if len(results) != 5 {
+		t.Fatalf("results count = %d, want 5", len(results))
+	}
+
+	// Results should be sorted by ruleId
+	expected := []struct {
+		ruleID string
+		level  string
+	}{
+		{"ENV001", "warning"},
+		{"ENV002", "error"},
+		{"ENV003", "warning"},
+		{"ENV004", "warning"},
+		{"ENV005", "error"},
+	}
+	for i, exp := range expected {
+		if results[i].RuleID != exp.ruleID {
+			t.Errorf("results[%d].RuleID = %q, want %q", i, results[i].RuleID, exp.ruleID)
+		}
+		if results[i].Level != exp.level {
+			t.Errorf("results[%d].Level = %q, want %q", i, results[i].Level, exp.level)
+		}
+		if results[i].Message.Text == "" {
+			t.Errorf("results[%d].Message.Text is empty", i)
+		}
+	}
+}
+
+// Task 2.3: ruleIndex references correct rule in filtered array
+func TestReportSARIF_RuleIndex(t *testing.T) {
+	data := types.ReportData{
+		Missing: map[string]types.Location{
+			"X": {FilePath: "a.go", LineNumber: 1},
+		},
+		DockerDeclaresUnused: []string{"Y"},
+	}
+	doc, _ := runSARIF(t, data)
+	rules := doc.Runs[0].Tool.Driver.Rules
+	results := doc.Runs[0].Results
+
+	for _, r := range results {
+		if r.RuleIndex < 0 || r.RuleIndex >= len(rules) {
+			t.Fatalf("ruleIndex %d out of range [0, %d)", r.RuleIndex, len(rules))
+		}
+		if rules[r.RuleIndex].ID != r.RuleID {
+			t.Errorf("ruleIndex %d points to rule %q, but result ruleId is %q",
+				r.RuleIndex, rules[r.RuleIndex].ID, r.RuleID)
+		}
+	}
+}
+
+// Task 2.3: Results sorted by ruleId then variable name
+func TestReportSARIF_ResultsSorted(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"ZEBRA", "ALPHA", "MIDDLE"},
+	}
+	doc, _ := runSARIF(t, data)
+	results := doc.Runs[0].Results
+
+	if len(results) != 3 {
+		t.Fatalf("results count = %d, want 3", len(results))
+	}
+	// All ENV001, sorted by variable name in message
+	for i := 1; i < len(results); i++ {
+		if results[i].Message.Text < results[i-1].Message.Text {
+			t.Errorf("results not sorted: %q before %q", results[i-1].Message.Text, results[i].Message.Text)
+		}
+	}
+}
+
+// Task 2.4: Physical location mapping for ENV002
+func TestReportSARIF_LocationENV002(t *testing.T) {
+	data := types.ReportData{
+		Missing: map[string]types.Location{
+			"DB_URL": {FilePath: "src/db.go", LineNumber: 42},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	results := doc.Runs[0].Results
+
+	if len(results) != 1 {
+		t.Fatalf("results count = %d, want 1", len(results))
+	}
+	r := results[0]
+	if len(r.Locations) != 1 {
+		t.Fatalf("locations count = %d, want 1", len(r.Locations))
+	}
+	loc := r.Locations[0].PhysicalLocation
+	if loc.ArtifactLocation.URI != "src/db.go" {
+		t.Errorf("uri = %q, want %q", loc.ArtifactLocation.URI, "src/db.go")
+	}
+	if loc.Region.StartLine != 42 {
+		t.Errorf("startLine = %d, want 42", loc.Region.StartLine)
+	}
+}
+
+// Task 2.4: Physical location mapping for ENV003 (first location)
+func TestReportSARIF_LocationENV003(t *testing.T) {
+	data := types.ReportData{
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"API_KEY": {
+				{FilePath: "first.go", LineNumber: 10},
+				{FilePath: "second.go", LineNumber: 20},
+			},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	r := doc.Runs[0].Results[0]
+	if len(r.Locations) != 1 {
+		t.Fatalf("locations count = %d, want 1", len(r.Locations))
+	}
+	if r.Locations[0].PhysicalLocation.ArtifactLocation.URI != "first.go" {
+		t.Errorf("uri = %q, want first.go", r.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	}
+}
+
+// Task 2.4: Physical location mapping for ENV005
+func TestReportSARIF_LocationENV005(t *testing.T) {
+	data := types.ReportData{
+		DockerUsesUndeclared: map[string]types.Location{
+			"SECRET": {FilePath: "Dockerfile", LineNumber: 7},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	r := doc.Runs[0].Results[0]
+	if len(r.Locations) != 1 {
+		t.Fatalf("locations count = %d, want 1", len(r.Locations))
+	}
+	loc := r.Locations[0].PhysicalLocation
+	if loc.ArtifactLocation.URI != "Dockerfile" {
+		t.Errorf("uri = %q, want Dockerfile", loc.ArtifactLocation.URI)
+	}
+	if loc.Region.StartLine != 7 {
+		t.Errorf("startLine = %d, want 7", loc.Region.StartLine)
+	}
+}
+
+// Task 2.4: ENV001 and ENV004 omit locations
+func TestReportSARIF_NoLocationsForENV001AndENV004(t *testing.T) {
+	data := types.ReportData{
+		Unused:               []string{"VAR1"},
+		DockerDeclaresUnused: []string{"VAR2"},
+	}
+	doc, _ := runSARIF(t, data)
+	for _, r := range doc.Runs[0].Results {
+		if len(r.Locations) != 0 {
+			t.Errorf("result %s should have no locations, got %d", r.RuleID, len(r.Locations))
+		}
+	}
+}
+
+// Task 2.4: Forward-slash path separators
+func TestReportSARIF_ForwardSlashPaths(t *testing.T) {
+	data := types.ReportData{
+		Missing: map[string]types.Location{
+			"VAR": {FilePath: "src/config/db.go", LineNumber: 1},
+		},
+	}
+	doc, _ := runSARIF(t, data)
+	uri := doc.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI
+	if uri != "src/config/db.go" {
+		t.Errorf("uri = %q, want forward-slash path", uri)
+	}
+}
+
+// Task 2.5: Empty results handling
+func TestReportSARIF_EmptyResults(t *testing.T) {
+	doc, raw := runSARIF(t, types.ReportData{})
+
+	if len(doc.Runs[0].Results) != 0 {
+		t.Errorf("results count = %d, want 0", len(doc.Runs[0].Results))
+	}
+	if len(doc.Runs[0].Tool.Driver.Rules) != 0 {
+		t.Errorf("rules count = %d, want 0", len(doc.Runs[0].Tool.Driver.Rules))
+	}
+	// Verify it's valid JSON
+	if !json.Valid([]byte(raw[:len(raw)-1])) { // trim trailing newline
+		t.Error("output is not valid JSON")
+	}
+}
+
+// Task 2.5: Nil slices in ReportData produce valid SARIF
+func TestReportSARIF_NilSlicesProduceValidSARIF(t *testing.T) {
+	data := types.ReportData{
+		Unused:               nil,
+		Missing:              nil,
+		CodeUsesNotInDocker:  nil,
+		DockerDeclaresUnused: nil,
+		DockerUsesUndeclared: nil,
+	}
+	doc, _ := runSARIF(t, data)
+	if doc.Runs[0].Results == nil {
+		t.Error("results should be non-nil empty slice")
+	}
+}
+
+// Task 2.6: Deterministic output
+func TestReportSARIF_Deterministic(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"Z_VAR", "A_VAR", "M_VAR"},
+		Missing: map[string]types.Location{
+			"X": {FilePath: "a.go", LineNumber: 1},
+			"B": {FilePath: "b.go", LineNumber: 2},
+		},
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"Q": {{FilePath: "q.go", LineNumber: 3}},
+		},
+		DockerDeclaresUnused: []string{"W", "D"},
+		DockerUsesUndeclared: map[string]types.Location{
+			"R": {FilePath: "Dockerfile", LineNumber: 4},
+		},
+	}
+
+	var out1, err1 bytes.Buffer
+	r1 := NewReporter(&out1, &err1)
+	if err := r1.ReportSARIF(data); err != nil {
+		t.Fatal(err)
+	}
+
+	var out2, err2 bytes.Buffer
+	r2 := NewReporter(&out2, &err2)
+	if err := r2.ReportSARIF(data); err != nil {
+		t.Fatal(err)
+	}
+
+	if out1.String() != out2.String() {
+		t.Error("output is not deterministic")
+	}
+}
+
+// Task 2.6: 2-space indentation and trailing newline
+func TestReportSARIF_IndentationAndTrailingNewline(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	r := NewReporter(&out, &errBuf)
+	if err := r.ReportSARIF(types.ReportData{}); err != nil {
+		t.Fatal(err)
+	}
+	raw := out.String()
+	// Trailing newline
+	if raw[len(raw)-1] != '\n' {
+		t.Error("output does not end with newline")
+	}
+	// 2-space indentation (check for "  " prefix on indented lines)
+	if !bytes.Contains(out.Bytes(), []byte("\n  \"")) {
+		t.Error("output does not use 2-space indentation")
+	}
+}

--- a/internal/reporter/testdata/sarif_expected_empty.json
+++ b/internal/reporter/testdata/sarif_expected_empty.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "capture",
+          "informationUri": "https://github.com/syncd-one/syncd",
+          "rules": null
+        }
+      },
+      "results": []
+    }
+  ]
+}

--- a/internal/reporter/testdata/sarif_expected_full.json
+++ b/internal/reporter/testdata/sarif_expected_full.json
@@ -1,0 +1,134 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "capture",
+          "informationUri": "https://github.com/syncd-one/syncd",
+          "rules": [
+            {
+              "id": "ENV001",
+              "name": "unused-variable",
+              "shortDescription": {
+                "text": "Variable is declared in .env but not used in code"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#unused-variable"
+            },
+            {
+              "id": "ENV002",
+              "name": "missing-variable",
+              "shortDescription": {
+                "text": "Variable is used in code but not declared in .env"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#missing-variable"
+            },
+            {
+              "id": "ENV003",
+              "name": "code-uses-not-in-docker",
+              "shortDescription": {
+                "text": "Variable is used in code but not declared in Dockerfile or .env"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#code-uses-not-in-docker"
+            },
+            {
+              "id": "ENV004",
+              "name": "docker-declares-unused",
+              "shortDescription": {
+                "text": "Variable is declared in Dockerfile but not used in code"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#docker-declares-unused"
+            },
+            {
+              "id": "ENV005",
+              "name": "docker-uses-undeclared",
+              "shortDescription": {
+                "text": "Variable is used in Dockerfile but not declared"
+              },
+              "helpUri": "https://github.com/syncd-one/syncd#docker-uses-undeclared"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "ENV001",
+          "ruleIndex": 0,
+          "level": "warning",
+          "message": {
+            "text": "UNUSED_VAR: Variable is declared in .env but not used in code"
+          }
+        },
+        {
+          "ruleId": "ENV002",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "MISSING_VAR: Variable is used in code but not declared in .env"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.go"
+                },
+                "region": {
+                  "startLine": 10
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ENV003",
+          "ruleIndex": 2,
+          "level": "warning",
+          "message": {
+            "text": "CODE_VAR: Variable is used in code but not declared in Dockerfile or .env"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/config.go"
+                },
+                "region": {
+                  "startLine": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ENV004",
+          "ruleIndex": 3,
+          "level": "warning",
+          "message": {
+            "text": "DOCKER_UNUSED: Variable is declared in Dockerfile but not used in code"
+          }
+        },
+        {
+          "ruleId": "ENV005",
+          "ruleIndex": 4,
+          "level": "error",
+          "message": {
+            "text": "DOCKER_UNDECL: Variable is used in Dockerfile but not declared"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
+                "region": {
+                  "startLine": 5
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/types/sarif.go
+++ b/internal/types/sarif.go
@@ -1,0 +1,69 @@
+package types
+
+// SARIFDocument is the top-level SARIF 2.1.0 envelope.
+type SARIFDocument struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema"`
+	Runs    []SARIFRun `json:"runs"`
+}
+
+// SARIFRun represents a single analysis invocation.
+type SARIFRun struct {
+	Tool    SARIFTool     `json:"tool"`
+	Results []SARIFResult `json:"results"`
+}
+
+// SARIFTool describes the analysis tool.
+type SARIFTool struct {
+	Driver SARIFDriver `json:"driver"`
+}
+
+// SARIFDriver contains tool metadata and rule definitions.
+type SARIFDriver struct {
+	Name           string                     `json:"name"`
+	InformationURI string                     `json:"informationUri"`
+	Rules          []SARIFReportingDescriptor `json:"rules"`
+}
+
+// SARIFReportingDescriptor defines a single rule.
+type SARIFReportingDescriptor struct {
+	ID               string       `json:"id"`
+	Name             string       `json:"name"`
+	ShortDescription SARIFMessage `json:"shortDescription"`
+	HelpURI          string       `json:"helpUri"`
+}
+
+// SARIFResult represents a single finding.
+type SARIFResult struct {
+	RuleID    string          `json:"ruleId"`
+	RuleIndex int             `json:"ruleIndex"`
+	Level     string          `json:"level"`
+	Message   SARIFMessage    `json:"message"`
+	Locations []SARIFLocation `json:"locations,omitempty"`
+}
+
+// SARIFMessage holds a human-readable text message.
+type SARIFMessage struct {
+	Text string `json:"text"`
+}
+
+// SARIFLocation wraps a physical location.
+type SARIFLocation struct {
+	PhysicalLocation SARIFPhysicalLocation `json:"physicalLocation"`
+}
+
+// SARIFPhysicalLocation contains file and region info.
+type SARIFPhysicalLocation struct {
+	ArtifactLocation SARIFArtifactLocation `json:"artifactLocation"`
+	Region           SARIFRegion           `json:"region"`
+}
+
+// SARIFArtifactLocation identifies the file.
+type SARIFArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+// SARIFRegion identifies the line within the file.
+type SARIFRegion struct {
+	StartLine int `json:"startLine"`
+}

--- a/internal/types/sarif_test.go
+++ b/internal/types/sarif_test.go
@@ -1,0 +1,131 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSARIFDocumentJSONKeys(t *testing.T) {
+	doc := SARIFDocument{
+		Version: "2.1.0",
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+		Runs: []SARIFRun{
+			{
+				Tool: SARIFTool{
+					Driver: SARIFDriver{
+						Name:           "capture",
+						InformationURI: "https://github.com/syncd-one/syncd",
+						Rules: []SARIFReportingDescriptor{
+							{
+								ID:               "ENV001",
+								Name:             "unused-variable",
+								ShortDescription: SARIFMessage{Text: "Variable declared but not used"},
+								HelpURI:          "https://github.com/syncd-one/syncd#unused-variable",
+							},
+						},
+					},
+				},
+				Results: []SARIFResult{
+					{
+						RuleID:    "ENV002",
+						RuleIndex: 0,
+						Level:     "error",
+						Message:   SARIFMessage{Text: "Missing variable: DB_HOST"},
+						Locations: []SARIFLocation{
+							{
+								PhysicalLocation: SARIFPhysicalLocation{
+									ArtifactLocation: SARIFArtifactLocation{URI: "src/main.go"},
+									Region:           SARIFRegion{StartLine: 10},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal SARIFDocument: %v", err)
+	}
+
+	output := string(data)
+
+	// Verify camelCase JSON keys from SARIF 2.1.0 spec
+	expectedKeys := []string{
+		`"$schema"`,
+		`"informationUri"`,
+		`"shortDescription"`,
+		`"helpUri"`,
+		`"ruleId"`,
+		`"ruleIndex"`,
+		`"physicalLocation"`,
+		`"artifactLocation"`,
+		`"startLine"`,
+	}
+
+	for _, key := range expectedKeys {
+		if !strings.Contains(output, key) {
+			t.Errorf("Expected JSON to contain key %s, but it was not found", key)
+		}
+	}
+}
+
+func TestSARIFResultOmitsLocationsWhenNil(t *testing.T) {
+	result := SARIFResult{
+		RuleID:    "ENV001",
+		RuleIndex: 0,
+		Level:     "warning",
+		Message:   SARIFMessage{Text: "Unused variable: UNUSED_VAR"},
+		Locations: nil,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Failed to marshal SARIFResult: %v", err)
+	}
+
+	output := string(data)
+
+	if strings.Contains(output, `"locations"`) {
+		t.Error("Expected 'locations' key to be omitted when Locations is nil")
+	}
+}
+
+func TestSARIFResultIncludesLocationsWhenPopulated(t *testing.T) {
+	result := SARIFResult{
+		RuleID:    "ENV002",
+		RuleIndex: 0,
+		Level:     "error",
+		Message:   SARIFMessage{Text: "Missing variable: API_KEY"},
+		Locations: []SARIFLocation{
+			{
+				PhysicalLocation: SARIFPhysicalLocation{
+					ArtifactLocation: SARIFArtifactLocation{URI: "src/config.go"},
+					Region:           SARIFRegion{StartLine: 25},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Failed to marshal SARIFResult: %v", err)
+	}
+
+	output := string(data)
+
+	if !strings.Contains(output, `"locations"`) {
+		t.Error("Expected 'locations' key to be present when Locations is populated")
+	}
+
+	if !strings.Contains(output, `"src/config.go"`) {
+		t.Error("Expected location URI 'src/config.go' in output")
+	}
+
+	if !strings.Contains(output, `"startLine":25`) {
+		t.Error("Expected startLine 25 in output")
+	}
+}


### PR DESCRIPTION
- Add `sarif` as valid format option to scan command alongside `text` and `json`
- Implement `ReportSARIF` method in reporter to convert ReportData to SARIF 2.1.0 structs
- Create SARIF type definitions in internal/types/sarif.go with full 2.1.0 schema support
- Map mismatch categories to SARIF rule IDs (ENV001-ENV005) with appropriate severity levels
- Sort results deterministically by ruleId then variable name for consistent CI/CD output
- Add comprehensive SARIF reporter tests including golden tests and property-based tests
- Include SARIF documentation and integration tests