### PR TITLE
feat(scan): support multiple env files with last file wins precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ make install
 capture scan --dir ./project --env-file .env
 ```
 
+### Multiple Env Files (Last File Wins)
+
+```bash
+capture scan --dir ./project \
+  --env-file .env \
+  --env-file .env.local \
+  --env-file .env.production
+```
+
 ### With Ignore Patterns
 
 ```bash
@@ -108,7 +117,7 @@ Dockerfile uses undeclared variables:
 ## Command-Line Options
 
 - `--dir` (required): Directory to scan for source files
-- `--env-file` (required): Path to the .env file
+- `--env-file` (required, repeatable): Path to an env file. When repeated, later files override earlier ones for declaration source.
 - `--ignore` (optional): Comma-separated list of directories to ignore
 - `--format` (optional): Output format - `text` (default), `json`, or `sarif`
 
@@ -117,6 +126,9 @@ Dockerfile uses undeclared variables:
 - **0**: No mismatches detected (success)
 - **1**: Mismatches found (unused or missing variables)
 - **2**: Configuration error (missing file, invalid flags, permissions)
+
+If one of multiple `--env-file` values is unreadable, `capture` prints a warning and continues with readable files.
+If none of the provided/default env files are readable, `capture` exits with code `2`.
 
 ## Supported Languages
 

--- a/cmd/capture/cmd/scan.go
+++ b/cmd/capture/cmd/scan.go
@@ -19,10 +19,10 @@ import (
 
 // ScanConfig holds the configuration for the scan command
 type ScanConfig struct {
-	Dir     string
-	EnvFile string
-	Ignore  []string
-	Format  string
+	Dir      string
+	EnvFiles []string
+	Ignore   []string
+	Format   string
 }
 
 var scanConfig ScanConfig
@@ -39,7 +39,7 @@ The tool will:
   - Detect variable usage in source code (JS, TS, Go, Python)
   - Report mismatches and inconsistencies`,
 	Example: `  capture scan --dir ./project --env-file .env
-  capture scan --dir . --env-file .env --ignore vendor,tmp
+  capture scan --dir . --env-file .env --env-file .env.local --ignore vendor,tmp
   capture scan --dir . --env-file .env --format json`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -49,7 +49,7 @@ The tool will:
 func init() {
 	// Define flags
 	scanCmd.Flags().StringVar(&scanConfig.Dir, "dir", ".", "Directory to scan (required)")
-	scanCmd.Flags().StringVar(&scanConfig.EnvFile, "env-file", ".env", "Path to .env file (required)")
+	scanCmd.Flags().StringSliceVar(&scanConfig.EnvFiles, "env-file", []string{".env"}, "Path to .env file (repeatable). Later files override earlier ones")
 	scanCmd.Flags().StringSliceVar(&scanConfig.Ignore, "ignore", []string{}, "Comma-separated list of directories to ignore")
 	scanCmd.Flags().StringVar(&scanConfig.Format, "format", "text", "Output format: text, json, or sarif")
 }
@@ -59,12 +59,6 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if scanConfig.Format != "text" && scanConfig.Format != "json" && scanConfig.Format != "sarif" {
 		fmt.Fprintf(os.Stderr, "Error: invalid format '%s'. Must be 'text', 'json', or 'sarif'\n", scanConfig.Format)
 		return NewExitError(fmt.Errorf("invalid format"), 2)
-	}
-
-	// Validate .env file exists
-	if _, err := os.Stat(scanConfig.EnvFile); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: .env file does not exist: %s\n", scanConfig.EnvFile)
-		return NewExitError(err, 2)
 	}
 
 	// Validate directory exists
@@ -105,10 +99,27 @@ func executeScan(config *ScanConfig) int {
 	diffEngine := diff.NewDiffEngine()
 	rep := reporter.NewReporter(os.Stdout, os.Stderr)
 
-	// Step 1: Parse .env file
-	declared, err := envParser.Parse(config.EnvFile)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to parse .env file: %v\n", err)
+	// Step 1: Parse .env files in order. Later files override earlier ones.
+	declared := make(map[string]bool)
+	declaredSources := make(map[string]string)
+	parsedEnvFiles := 0
+
+	for _, envFile := range config.EnvFiles {
+		parsedDeclared, err := envParser.Parse(envFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse .env file %s: %v\n", envFile, err)
+			continue
+		}
+
+		parsedEnvFiles++
+		for varName := range parsedDeclared {
+			declared[varName] = true
+			declaredSources[varName] = envFile
+		}
+	}
+
+	if parsedEnvFiles == 0 {
+		fmt.Fprintln(os.Stderr, "Error: no readable env files found from --env-file values")
 		return 2
 	}
 
@@ -233,6 +244,7 @@ func executeScan(config *ScanConfig) int {
 		Unused:               diffResult.Unused,
 		Missing:              make(map[string]types.Location),
 		AllLocations:         allLocations,
+		DeclaredSources:      declaredSources,
 		FilesScanned:         len(sourceFiles) + len(dockerfiles),
 		VariablesDeclared:    len(declared),
 		VariablesUsed:        len(used),

--- a/cmd/capture/main_test.go
+++ b/cmd/capture/main_test.go
@@ -137,8 +137,74 @@ func TestCLI_MissingEnvFile(t *testing.T) {
 
 	// Should output error message to stderr
 	stderrOutput := stderr.String()
-	if !strings.Contains(stderrOutput, "does not exist") {
-		t.Errorf("Expected error message about missing file in stderr, got: %s", stderrOutput)
+	if !strings.Contains(stderrOutput, "no readable env files found") {
+		t.Errorf("Expected error message about unreadable env files in stderr, got: %s", stderrOutput)
+	}
+}
+
+// TestCLI_MultipleEnvFiles tests repeated --env-file handling.
+func TestCLI_MultipleEnvFiles(t *testing.T) {
+	binary := buildBinary(t)
+
+	tmpDir := t.TempDir()
+	baseEnv := filepath.Join(tmpDir, ".env")
+	localEnv := filepath.Join(tmpDir, ".env.local")
+	srcFile := filepath.Join(tmpDir, "app.js")
+
+	if err := os.WriteFile(baseEnv, []byte("API_KEY=base\n"), 0644); err != nil {
+		t.Fatalf("Failed to write base .env file: %v", err)
+	}
+	if err := os.WriteFile(localEnv, []byte("LOCAL_ONLY=1\n"), 0644); err != nil {
+		t.Fatalf("Failed to write local .env file: %v", err)
+	}
+	if err := os.WriteFile(srcFile, []byte("console.log(process.env.API_KEY, process.env.LOCAL_ONLY);\n"), 0644); err != nil {
+		t.Fatalf("Failed to write source file: %v", err)
+	}
+
+	cmd := exec.Command(binary, "scan", "--dir", tmpDir, "--env-file", baseEnv, "--env-file", localEnv)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("Expected exit code 0, got error: %v\nStdout: %s\nStderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "No environment mismatches found.") {
+		t.Errorf("Expected success output, got: %s", stdout.String())
+	}
+}
+
+// TestCLI_MissingEnvFile_WarnAndContinue ensures a missing env file does not fail the scan
+// if at least one env file is readable.
+func TestCLI_MissingEnvFile_WarnAndContinue(t *testing.T) {
+	binary := buildBinary(t)
+
+	tmpDir := t.TempDir()
+	existingEnv := filepath.Join(tmpDir, ".env")
+	missingEnv := filepath.Join(tmpDir, ".env.local")
+	srcFile := filepath.Join(tmpDir, "app.js")
+
+	if err := os.WriteFile(existingEnv, []byte("API_KEY=test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write .env file: %v", err)
+	}
+	if err := os.WriteFile(srcFile, []byte("const key = process.env.API_KEY;\n"), 0644); err != nil {
+		t.Fatalf("Failed to write source file: %v", err)
+	}
+
+	cmd := exec.Command(binary, "scan", "--dir", tmpDir, "--env-file", existingEnv, "--env-file", missingEnv)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("Expected exit code 0, got error: %v\nStdout: %s\nStderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "Warning: failed to parse .env file") {
+		t.Errorf("Expected warning for missing env file, got stderr: %s", stderr.String())
 	}
 }
 
@@ -193,7 +259,7 @@ func TestCLI_DefaultFlagBehavior(t *testing.T) {
 		{
 			name:          "missing dir flag uses default and fails if not exists",
 			args:          []string{"scan", "--env-file", ".env"},
-			expectedInErr: "does not exist",
+			expectedInErr: "no readable env files found",
 			setupFunc: func(t *testing.T) string {
 				// Create temp dir without .env file
 				tmpDir := t.TempDir()
@@ -203,7 +269,7 @@ func TestCLI_DefaultFlagBehavior(t *testing.T) {
 		{
 			name:          "missing env-file flag uses default and fails if not exists",
 			args:          []string{"scan", "--dir", "."},
-			expectedInErr: "does not exist",
+			expectedInErr: "no readable env files found",
 			setupFunc: func(t *testing.T) string {
 				// Create temp dir without .env file
 				tmpDir := t.TempDir()
@@ -213,7 +279,7 @@ func TestCLI_DefaultFlagBehavior(t *testing.T) {
 		{
 			name:          "missing both flags uses defaults and fails",
 			args:          []string{"scan"},
-			expectedInErr: "does not exist",
+			expectedInErr: "no readable env files found",
 			setupFunc: func(t *testing.T) string {
 				// Create temp dir without .env file
 				tmpDir := t.TempDir()

--- a/docs/JSON_OUTPUT.md
+++ b/docs/JSON_OUTPUT.md
@@ -8,6 +8,12 @@ The `--format json` flag produces machine-readable JSON output for CI/CD integra
 capture scan --dir . --env-file .env --format json
 ```
 
+You can provide multiple env files in precedence order:
+
+```bash
+capture scan --dir . --env-file .env --env-file .env.local --format json
+```
+
 ## Output Structure
 
 The JSON output follows this schema:
@@ -21,6 +27,10 @@ The JSON output follows this schema:
     "mismatches_found": 3
   },
   "unused": ["OLD_API_KEY", "DEPRECATED_URL"],
+  "declared_sources": {
+    "DATABASE_URL": ".env.local",
+    "API_KEY": ".env"
+  },
   "missing": [
     {
       "variable": "DATABASE_URL",
@@ -68,6 +78,15 @@ List of variable names declared in .env but not used in source code.
 ```json
 "unused": ["OLD_API_KEY", "DEPRECATED_URL"]
 ```
+
+### declared_sources Object
+
+Mapping of variable name to the env file that declared it after merge precedence is applied.
+
+- Key: variable name
+- Value: source env file path
+
+When multiple `--env-file` flags are provided, later files override earlier files.
 
 ### Missing Array
 
@@ -137,6 +156,9 @@ Exit codes remain the same regardless of output format:
 - **0**: No mismatches detected
 - **1**: Mismatches found
 - **2**: Configuration error
+
+When multiple `--env-file` flags are used, unreadable files generate warnings and are skipped.
+If all env files are unreadable, scan exits with code `2`.
 
 ## Examples
 

--- a/docs/SARIF_OUTPUT.md
+++ b/docs/SARIF_OUTPUT.md
@@ -8,6 +8,12 @@ The `--format sarif` flag produces output in [SARIF](https://sarifweb.azurewebsi
 capture scan --dir . --env-file .env --format sarif
 ```
 
+You can provide multiple env files in precedence order:
+
+```bash
+capture scan --dir . --env-file .env --env-file .env.local --format sarif
+```
+
 To save results to a file:
 
 ```bash
@@ -100,6 +106,9 @@ The following example shows SARIF output from a scan that found all five categor
           "level": "warning",
           "message": {
             "text": "UNUSED_VAR: Variable is declared in .env but not used in code"
+          },
+          "properties": {
+            "declared_source": ".env"
           }
         },
         {
@@ -120,7 +129,10 @@ The following example shows SARIF output from a scan that found all five categor
                 }
               }
             }
-          ]
+          ],
+          "properties": {
+            "declared_source": ".env.local"
+          }
         },
         {
           "ruleId": "ENV003",
@@ -209,6 +221,7 @@ When no mismatches are found, the output is a valid SARIF document with empty `r
 - **tool.driver.rules**: Only rules with at least one result are included
 - **results**: Sorted by `ruleId`, then alphabetically by variable name
 - **locations**: Included for ENV002, ENV003, and ENV005 results when location data is available; omitted for ENV001 and ENV004
+- **properties.declared_source**: Included for ENV001, ENV002, and ENV003 when declaration source is known
 
 ## Location Data
 
@@ -233,6 +246,9 @@ Exit codes are the same regardless of output format:
 - **0**: No mismatches detected
 - **1**: Mismatches found
 - **2**: Configuration error
+
+When multiple `--env-file` flags are used, unreadable files generate warnings and are skipped.
+If all env files are unreadable, scan exits with code `2`.
 
 ## GitHub Actions Integration
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -81,6 +81,11 @@ func (r *ReporterImpl) ReportJSON(data types.ReportData) error {
 		unused = []string{}
 	}
 
+	declaredSources := data.DeclaredSources
+	if declaredSources == nil {
+		declaredSources = map[string]string{}
+	}
+
 	dockerDeclaresUnused := data.DockerDeclaresUnused
 	if dockerDeclaresUnused == nil {
 		dockerDeclaresUnused = []string{}
@@ -160,8 +165,9 @@ func (r *ReporterImpl) ReportJSON(data types.ReportData) error {
 			VariablesUsed:     data.VariablesUsed,
 			MismatchesFound:   mismatchesFound,
 		},
-		Unused:  unused,
-		Missing: missing,
+		Unused:          unused,
+		Missing:         missing,
+		DeclaredSources: declaredSources,
 		DockerfileIssues: types.DockerfileIssues{
 			CodeUsesNotInDocker:  codeUsesNotInDocker,
 			DockerDeclaresUnused: dockerDeclaresUnused,

--- a/internal/reporter/reporter_json_test.go
+++ b/internal/reporter/reporter_json_test.go
@@ -357,3 +357,42 @@ func TestReporterImpl_ReportJSON_NilLocations(t *testing.T) {
 
 	t.Logf("JSON output:\n%s", jsonStr)
 }
+
+func TestReporterImpl_ReportJSON_DeclaredSources(t *testing.T) {
+	data := types.ReportData{
+		Unused:               []string{},
+		Missing:              map[string]types.Location{},
+		AllLocations:         map[string][]types.Location{},
+		DeclaredSources:      map[string]string{"API_KEY": ".env.local", "DATABASE_URL": ".env"},
+		FilesScanned:         2,
+		VariablesDeclared:    2,
+		VariablesUsed:        0,
+		CodeUsesNotInDocker:  map[string][]types.Location{},
+		DockerDeclaresUnused: []string{},
+		DockerUsesUndeclared: map[string]types.Location{},
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	r := NewReporter(&out, &errOut)
+
+	err := r.ReportJSON(data)
+	if err != nil {
+		t.Fatalf("ReportJSON() error = %v", err)
+	}
+
+	var result types.JSONOutput
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if len(result.DeclaredSources) != 2 {
+		t.Fatalf("DeclaredSources count = %d, want 2", len(result.DeclaredSources))
+	}
+	if result.DeclaredSources["API_KEY"] != ".env.local" {
+		t.Errorf("DeclaredSources[API_KEY] = %q, want .env.local", result.DeclaredSources["API_KEY"])
+	}
+	if result.DeclaredSources["DATABASE_URL"] != ".env" {
+		t.Errorf("DeclaredSources[DATABASE_URL] = %q, want .env", result.DeclaredSources["DATABASE_URL"])
+	}
+}

--- a/internal/reporter/reporter_sarif.go
+++ b/internal/reporter/reporter_sarif.go
@@ -74,7 +74,7 @@ func (r *ReporterImpl) ReportSARIF(data types.ReportData) error {
 
 // buildSARIFRules returns the filtered, sorted rules array for the given active rule IDs.
 func buildSARIFRules(activeRuleIDs map[string]bool) []types.SARIFReportingDescriptor {
-	rules := []types.SARIFReportingDescriptor{}
+	var rules []types.SARIFReportingDescriptor
 	for _, def := range sarifRules {
 		if !activeRuleIDs[def.id] {
 			continue
@@ -111,11 +111,13 @@ func buildSARIFResults(data types.ReportData) ([]types.SARIFResult, map[string]b
 	sort.Strings(sortedUnused)
 	for _, varName := range sortedUnused {
 		activeRuleIDs["ENV001"] = true
-		results = append(results, types.SARIFResult{
+		result := types.SARIFResult{
 			RuleID:  "ENV001",
 			Level:   "warning",
 			Message: types.SARIFMessage{Text: fmt.Sprintf("%s: Variable is declared in .env but not used in code", varName)},
-		})
+		}
+		addDeclaredSourceProperty(&result, varName, data.DeclaredSources)
+		results = append(results, result)
 	}
 
 	// ENV002 - missing variables (with locations from data.Missing)
@@ -133,6 +135,7 @@ func buildSARIFResults(data types.ReportData) ([]types.SARIFResult, map[string]b
 				makeLocation(loc.FilePath, loc.LineNumber),
 			}
 		}
+		addDeclaredSourceProperty(&result, varName, data.DeclaredSources)
 		results = append(results, result)
 	}
 
@@ -151,6 +154,7 @@ func buildSARIFResults(data types.ReportData) ([]types.SARIFResult, map[string]b
 				makeLocation(locs[0].FilePath, locs[0].LineNumber),
 			}
 		}
+		addDeclaredSourceProperty(&result, varName, data.DeclaredSources)
 		results = append(results, result)
 	}
 
@@ -217,6 +221,20 @@ func makeLocation(filePath string, lineNumber int) types.SARIFLocation {
 			},
 		},
 	}
+}
+
+func addDeclaredSourceProperty(result *types.SARIFResult, varName string, declaredSources map[string]string) {
+	if declaredSources == nil {
+		return
+	}
+	source, ok := declaredSources[varName]
+	if !ok || source == "" {
+		return
+	}
+	if result.Properties == nil {
+		result.Properties = make(map[string]string)
+	}
+	result.Properties["declared_source"] = filepath.ToSlash(source)
 }
 
 // sortedKeys returns sorted keys from a map[string]Location.

--- a/internal/reporter/reporter_sarif_test.go
+++ b/internal/reporter/reporter_sarif_test.go
@@ -320,6 +320,45 @@ func TestReportSARIF_ForwardSlashPaths(t *testing.T) {
 	}
 }
 
+func TestReportSARIF_DeclaredSourceProperties(t *testing.T) {
+	data := types.ReportData{
+		Unused: []string{"UNUSED_VAR"},
+		Missing: map[string]types.Location{
+			"MISSING_VAR": {FilePath: "src/app.go", LineNumber: 10},
+		},
+		CodeUsesNotInDocker: map[string][]types.Location{
+			"CODE_VAR": {{FilePath: "src/config.go", LineNumber: 20}},
+		},
+		DeclaredSources: map[string]string{
+			"UNUSED_VAR":  ".env",
+			"MISSING_VAR": ".env.local",
+			"CODE_VAR":    "config/.env.production",
+		},
+	}
+
+	doc, _ := runSARIF(t, data)
+	results := doc.Runs[0].Results
+
+	wantByRule := map[string]string{
+		"ENV001": ".env",
+		"ENV002": ".env.local",
+		"ENV003": "config/.env.production",
+	}
+
+	for _, r := range results {
+		want, tracked := wantByRule[r.RuleID]
+		if !tracked {
+			continue
+		}
+		if r.Properties == nil {
+			t.Fatalf("result %s expected properties, got nil", r.RuleID)
+		}
+		if got := r.Properties["declared_source"]; got != want {
+			t.Errorf("result %s declared_source = %q, want %q", r.RuleID, got, want)
+		}
+	}
+}
+
 // Task 2.5: Empty results handling
 func TestReportSARIF_EmptyResults(t *testing.T) {
 	doc, raw := runSARIF(t, types.ReportData{})

--- a/internal/types/sarif.go
+++ b/internal/types/sarif.go
@@ -35,11 +35,12 @@ type SARIFReportingDescriptor struct {
 
 // SARIFResult represents a single finding.
 type SARIFResult struct {
-	RuleID    string          `json:"ruleId"`
-	RuleIndex int             `json:"ruleIndex"`
-	Level     string          `json:"level"`
-	Message   SARIFMessage    `json:"message"`
-	Locations []SARIFLocation `json:"locations,omitempty"`
+	RuleID     string            `json:"ruleId"`
+	RuleIndex  int               `json:"ruleIndex"`
+	Level      string            `json:"level"`
+	Message    SARIFMessage      `json:"message"`
+	Locations  []SARIFLocation   `json:"locations,omitempty"`
+	Properties map[string]string `json:"properties,omitempty"`
 }
 
 // SARIFMessage holds a human-readable text message.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -18,6 +18,7 @@ type ReportData struct {
 	Missing map[string]Location // Variables used but not declared, mapped to first location
 	// Additional data for JSON output
 	AllLocations         map[string][]Location // All locations for each variable
+	DeclaredSources      map[string]string     // Variable -> declaring env file (last file wins)
 	FilesScanned         int
 	VariablesDeclared    int
 	VariablesUsed        int
@@ -31,6 +32,7 @@ type JSONOutput struct {
 	Summary          Summary           `json:"summary"`
 	Unused           []string          `json:"unused"`
 	Missing          []MissingVariable `json:"missing"`
+	DeclaredSources  map[string]string `json:"declared_sources"`
 	DockerfileIssues DockerfileIssues  `json:"dockerfile_issues"`
 }
 

--- a/testdata/.env.multiple-2
+++ b/testdata/.env.multiple-2
@@ -1,0 +1,2 @@
+API_KEY=test_key
+DATABASE_URL=postgres://localhost/test


### PR DESCRIPTION
- Updated command-line options to accept multiple `--env-file` flags.
- Modified scan logic to parse multiple env files, overriding earlier declarations.
- Enhanced error handling for unreadable env files, allowing the scan to continue.
- Updated documentation and examples to reflect new functionality.
- Added tests for multiple env file handling and error scenarios.



resolves #6 